### PR TITLE
feat: 更纯粹的分享链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 
 * [X] 视频标题左边的“热门”等标签
   ![video_detail_label](./app/src/main/res/drawable/video_detail_label.png)
+* [X] 更纯粹的链接分享
+  原来分享链接是`https://b23.tv/xxxxxxx`这样的，让它变成`https://www.bilibili.com/video/BVxxxxx`这样的
 
 ### 视频评论区
 
@@ -49,5 +51,5 @@
 
 下面仅列出测试过的版本，相近版本大概率能兼容
 
-* MBGA v1.0.0
-  * 兼容国际版3.18.2
+* MBGA v1.0.0 ~ v1.0.2
+  * 兼容国际版 未知 ~ 3.18.2 ~ 未知

--- a/app/src/main/java/top/trangle/mbga/hook/VideoDetailHooker.kt
+++ b/app/src/main/java/top/trangle/mbga/hook/VideoDetailHooker.kt
@@ -1,6 +1,7 @@
 package top.trangle.mbga.hook
 
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
+import com.highcapable.yukihookapi.hook.factory.field
 import com.highcapable.yukihookapi.hook.factory.method
 
 object VideoDetailHooker : YukiBaseHooker() {
@@ -18,6 +19,25 @@ object VideoDetailHooker : YukiBaseHooker() {
                 if (prefs.getBoolean("vid_detail_disable_label")) {
                     resultNull()
                 }
+            }
+        }
+
+        val clzShareResult = "com.bilibili.lib.sharewrapper.online.api.ShareClickResult".toClass()
+        val contentField = clzShareResult.field { name = "content" }
+
+        val clzShareTargetTask =
+            "com.bilibili.app.comm.supermenu.share.v2.ShareTargetTask\$f".toClass()
+        val shareTaskCallback = clzShareTargetTask.method { name = "l" }
+
+        "ah1.c".toClass().method { name = "c" }.hook {
+            replaceUnit {
+                if (!prefs.getBoolean("vid_detail_disable_short_link")) {
+                    callOriginal()
+                    return@replaceUnit
+                }
+                val result = clzShareResult.getDeclaredConstructor().newInstance()
+                contentField.get(result).set(args[7])
+                shareTaskCallback.get(args[17]).invoke<Any>(result)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="setting_vid_detail">视频详情页</string>
     <string name="setting_vid_detail_no_label">干掉标题左侧标签</string>
     <string name="setting_vid_detail_no_label_hint">常见标签有：热门、活动，点击会打开新页面</string>
+    <string name="setting_vid_detail_no_short_link">分享时禁止使用短链</string>
+    <string name="setting_vid_detail_no_short_link_on">https://www.bilibili.com/video/BVxx</string>
+    <string name="setting_vid_detail_no_short_link_off">https://b23.tv/xxxxxxx</string>
 
     <string name="setting_vid_comment">视频评论区</string>
     <string name="setting_vid_comment_no_quick_reply">禁止快速回复</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -87,6 +87,15 @@
             app:iconSpaceReserved="false"
             app:key="vid_detail_disable_label"
             app:summary="@string/setting_vid_detail_no_label_hint" />
+        <SwitchPreferenceCompat
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:title="@string/setting_vid_detail_no_short_link"
+            app:iconSpaceReserved="false"
+            app:key="vid_detail_disable_short_link"
+            app:summaryOff="@string/setting_vid_detail_no_short_link_off"
+            app:summaryOn="@string/setting_vid_detail_no_short_link_on" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ project.android.minSdk=27
 project.android.targetSdk=34
 project.app.packageName=top.trangle.mbga
 project.app.versionName="1.0.2"
-project.app.versionCode=3
+project.app.versionCode=4


### PR DESCRIPTION
关联issue: #6 

将原有链接分享的短链`https://b23.tv/xxxxxxx`变成`https://www.bilibili.com/video/BVxxxxx`
