### PR TITLE
fix: 修复小窗模式下进入“我的”tab时添加搜索入口失败的问题

### DIFF
--- a/app/src/main/java/top/trangle/mbga/hook/MainActivityHooker.kt
+++ b/app/src/main/java/top/trangle/mbga/hook/MainActivityHooker.kt
@@ -10,7 +10,26 @@ import top.trangle.mbga.utils.subHook
 
 object MainActivityHooker : YukiBaseHooker() {
     override fun onHook() {
+        subHook(this::injectResources)
         subHook(this::hookMainCreate)
+    }
+
+    private fun injectResources() {
+        val clzActivity = "android.app.Activity".toClass()
+        clzActivity.method { name = "onConfigurationChanged" }
+            .hook {
+                before {
+                    val activity = instance as Activity
+                    activity.injectModuleAppResources()
+                }
+            }
+        clzActivity.method { name = "onCreate" }
+            .hook {
+                before {
+                    val activity = instance as Activity
+                    activity.injectModuleAppResources()
+                }
+            }
     }
 
     private fun hookMainCreate() {
@@ -18,7 +37,6 @@ object MainActivityHooker : YukiBaseHooker() {
             .hook {
                 after {
                     val activity = instance as Activity
-                    activity.injectModuleAppResources()
 
                     if (!prefs.isPreferencesAvailable) {
                         val intent =


### PR DESCRIPTION
## BUG表现

3.18.0中，打开B站，进入小窗模式，点击“我的”会发现搜索入口添加失败，报错无法找到注入的图片资源。

3.19.1中，打开B站，点击“我的”，然后进入小窗模式会直接闪退，报

```
06-21 22:42:38.535 16784 16784 E AndroidRuntime: FATAL EXCEPTION: main
--
06-21 22:42:38.535 16784 16784 E AndroidRuntime: Process: com.bilibili.app.in, PID: 16784
06-21 22:42:38.535 16784 16784 E AndroidRuntime: android.content.res.Resources$NotFoundException: Resource ID #0x510800a1
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.content.res.ResourcesImpl.getValueForDensity(ResourcesImpl.java:280)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.content.res.Resources.getDrawableForDensity(Resources.java:1042)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.content.res.Resources.getDrawable(Resources.java:982)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.content.res.Resources.getDrawable(Resources.java:957)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.facebook.drawee.generic.GenericDraweeHierarchy.setPlaceholderImage(BL:4)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.bilibili.lib.image2.fresco.FrescoGenericProperties$dayNightRefresh$1$1.invoke(BL:2)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.bilibili.lib.image2.fresco.FrescoGenericProperties$dayNightRefresh$1$1.invoke(BL:1)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.bilibili.lib.image2.fresco.FrescoGenericProperties.K(BL:3)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.bilibili.lib.image2.fresco.FrescoGenericProperties.y(BL:2)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.bilibili.lib.image2.fresco.u.b(BL:1)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.bilibili.lib.image2.view.BiliImageView.tint(BL:1)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:2)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.dz(BL:5)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.onSkinChange(BL:47)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment.onConfigurationChanged(BL:3)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.fragment.app.Fragment.performConfigurationChanged(BL:1)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.fragment.app.FragmentManager.dispatchConfigurationChanged(BL:4)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.fragment.app.FragmentManager.lambda$new$0(BL:2)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.fragment.app.FragmentManager.d(Unknown Source:0)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.fragment.app.q.accept(Unknown Source:4)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.activity.ComponentActivity.onConfigurationChanged(BL:3)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at androidx.appcompat.app.d.onConfigurationChanged(BL:1)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.ActivityThread.performActivityConfigurationChanged(ActivityThread.java:6409)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.ActivityThread.performConfigurationChangedForActivity(ActivityThread.java:6293)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.ActivityThread.handleActivityConfigurationChanged(ActivityThread.java:6737)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.ActivityThread.handleActivityConfigurationChanged(ActivityThread.java:6671)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.servertransaction.ActivityConfigurationChangeItem.execute(ActivityConfigurationChangeItem.java:55)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:149)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:99)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2589)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:224)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:318)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8759)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:561)
06-21 22:42:38.535 16784 16784 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)
```

## 修复方案

新增钩子，在`android.app.Activity.onCreate`和`android.app.Activity.onConfigurationChanged`中注入资源