### PR TITLE
feat: 移除“全屏播放时禁止展示在线人数”功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@
   ![video_player_dm_click](./app/src/main/res/drawable/video_player_dm_click.png)
 * 禁止展示反馈弹窗  
   ![video_player_qoe](./app/src/main/res/drawable/video_player_qoe.png)
-* 全屏时禁止展示在线人数  
+* ~全屏时禁止展示在线人数~ 该功能已移除，因为  
+  B站本来就支持，可在通过这个途径设置：B站设置->播放设置->其他（播放）设置->全屏播放画面展示同时在看人数  
   ![video_player_online_count](./app/src/main/res/drawable/video_player_online_count.png)
 
 ### 视频详情页

--- a/app/src/main/java/top/trangle/mbga/hook/VideoPlayerHooker.kt
+++ b/app/src/main/java/top/trangle/mbga/hook/VideoPlayerHooker.kt
@@ -6,8 +6,6 @@ import com.highcapable.yukihookapi.hook.factory.field
 import com.highcapable.yukihookapi.hook.factory.hasMethod
 import com.highcapable.yukihookapi.hook.factory.method
 import com.highcapable.yukihookapi.hook.log.YLog
-import top.trangle.mbga.BILI_IN_VER_3_18_2
-import top.trangle.mbga.BILI_IN_VER_3_19_0
 import top.trangle.mbga.utils.MyHooker
 
 object VideoPlayerHooker : MyHooker() {
@@ -19,8 +17,6 @@ object VideoPlayerHooker : MyHooker() {
         subHook(this::hookMultiWindowFullscreen)
         subHook(this::hookPortraitVideo)
         subHook(this::hookDmClick)
-        versionSpecifiedSubHook(this::hookOnlineCountV1, Long.MIN_VALUE..BILI_IN_VER_3_18_2)
-        versionSpecifiedSubHook(this::hookOnlineCountV2, BILI_IN_VER_3_19_0..Long.MAX_VALUE)
     }
 
     private fun hookOldVersion() {
@@ -168,27 +164,5 @@ object VideoPlayerHooker : MyHooker() {
             .toClass()
             .method { name = "setLocation" }
             .hook(YukiHookPriority.DEFAULT, dmClickHook)
-    }
-
-    private val onlineCountHook: (YukiMemberHookCreator.MemberHookCreator) -> Unit = {
-        it.before {
-            if (prefs.getBoolean("vid_player_disable_online_count")) {
-                args[0] = false
-            }
-        }
-    }
-
-    private fun hookOnlineCountV1() {
-        "tv.danmaku.biliplayerv2.service.interact.biz.chronos.chronosrpc.methods.send.DanmakuConfigChange\$Request"
-            .toClass()
-            .method { name = "setShowOnlineCount" }
-            .hook(YukiHookPriority.DEFAULT, onlineCountHook)
-    }
-
-    private fun hookOnlineCountV2() {
-        "tv.danmaku.biliplayerv2.service.interact.biz.chronos.chronosrpc.methods.send.DanmakuOnlineCountConfig\$Request"
-            .toClass()
-            .method { name = "setShowOnlineCount" }
-            .hook(YukiHookPriority.DEFAULT, onlineCountHook)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,7 +55,6 @@
     <string name="setting_vid_player_no_dm_click_off">点击弹幕时会弹出“点赞、复制、举报”浮窗</string>
     <string name="setting_vid_player_no_qoe">禁止展示反馈弹窗</string>
     <string name="setting_vid_player_no_qoe_hint">禁止展示“对音量均衡功能满意吗”此类的弹窗</string>
-    <string name="setting_vid_player_no_online_count">全屏时禁止展示在线人数</string>
 
     <string name="setting_vid_detail">视频详情页</string>
     <string name="setting_vid_detail_no_label">干掉标题左侧标签</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -143,10 +143,6 @@
             app:key="vid_player_disable_qoe"
             app:summary="@string/setting_vid_player_no_qoe_hint"
             app:title="@string/setting_vid_player_no_qoe" />
-        <SwitchPreferenceCompat
-            app:iconSpaceReserved="false"
-            app:key="vid_player_disable_online_count"
-            app:title="@string/setting_vid_player_no_online_count" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
B站本来就支持，可在通过这个途径设置：B站设置->播放设置->其他（播放）设置->全屏播放画面展示同时在看人数

没必要再通过模块隐藏了（其实是3.20.x hook点位变了，正好不用再找了）